### PR TITLE
Testing the Neon Ingestion

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+/lib/generated/prisma

--- a/client/app/api/get-repo/route.ts
+++ b/client/app/api/get-repo/route.ts
@@ -1,10 +1,16 @@
+// app/api/get-repo/route.ts
 import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
 
+export const runtime = "nodejs";
+
+// Existing helper unchanged
 async function getCountFromPaginatedApi(url: string, token: string) {
   const res = await fetch(url + "?per_page=1", {
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${token}`,
+      "User-Agent": "nextjs-app",
     },
   });
   if (!res.ok) {
@@ -12,12 +18,11 @@ async function getCountFromPaginatedApi(url: string, token: string) {
   }
   const linkHeader = res.headers.get("link");
   if (linkHeader) {
-    const lastPageMatch = linkHeader.match(/&page=(\d+)>;\s*rel="last"/);
+    const lastPageMatch = linkHeader.match(/[\?&]page=(\d+)>;\s*rel="last"/);
     if (lastPageMatch) {
       return Number(lastPageMatch[1]);
     }
   }
-  // if no pagination, only 1 page
   const data = await res.json();
   return Array.isArray(data) ? data.length : 0;
 }
@@ -34,7 +39,6 @@ export async function GET(request: Request) {
   }
 
   const githubAccessToken = process.env.GITHUB_ACCESS_TOKEN;
-
   if (!githubAccessToken) {
     return NextResponse.json(
       { error: "GitHub token not configured" },
@@ -43,42 +47,40 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Fetch main repo data
+    // 1) Fetch main repo data (unchanged)
     const repoRes = await fetch(`https://api.github.com/repos/${repoUrl}`, {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${githubAccessToken}`,
+        "User-Agent": "nextjs-app",
       },
     });
-
     if (!repoRes.ok) {
       return NextResponse.json(
         { error: "GitHub API error fetching repo details" },
         { status: repoRes.status }
       );
     }
-
     const repoData = await repoRes.json();
 
-    // Fetch branch count
+    // 2) Counts
     const branchCount = await getCountFromPaginatedApi(
       `https://api.github.com/repos/${repoUrl}/branches`,
       githubAccessToken
     );
-
-    // Fetch tag count
     const tagCount = await getCountFromPaginatedApi(
       `https://api.github.com/repos/${repoUrl}/tags`,
       githubAccessToken
     );
 
-    // Fetch open PR count via Search API
+    // 3) Open PR count via Search API
     const prSearchRes = await fetch(
       `https://api.github.com/search/issues?q=repo:${repoUrl}+is:pr+is:open&per_page=1`,
       {
         headers: {
           Accept: "application/vnd.github+json",
           Authorization: `Bearer ${githubAccessToken}`,
+          "User-Agent": "nextjs-app",
         },
       }
     );
@@ -91,8 +93,8 @@ export async function GET(request: Request) {
     const prSearchData = await prSearchRes.json();
     const openPrsCount = prSearchData.total_count;
 
-    // Fetch last commit date
-    let lastCommitDate = null;
+    // 4) Last commit date
+    let lastCommitDate: string | null = null;
     try {
       const commitRes = await fetch(
         `https://api.github.com/repos/${repoUrl}/commits?per_page=1`,
@@ -100,20 +102,21 @@ export async function GET(request: Request) {
           headers: {
             Accept: "application/vnd.github+json",
             Authorization: `Bearer ${githubAccessToken}`,
+            "User-Agent": "nextjs-app",
           },
         }
       );
       if (commitRes.ok) {
         const commitData = await commitRes.json();
         if (Array.isArray(commitData) && commitData.length > 0) {
-          lastCommitDate = commitData[0].commit?.committer?.date || null;
+          lastCommitDate = commitData[0]?.commit?.committer?.date || null;
         }
       }
     } catch {
       lastCommitDate = null;
     }
 
-    // Compose enhanced repo info
+    // 5) Compose enhanced repo info (unchanged)
     const enhancedRepoData = {
       ...repoData,
       branch_count: branchCount,
@@ -122,12 +125,154 @@ export async function GET(request: Request) {
       last_commit: lastCommitDate,
     };
 
+    // 6) Persist to DB (new)
+    try {
+      const [owner, name] = repoUrl.split("/");
+      const topics: string[] = Array.isArray(repoData.topics) ? repoData.topics : [];
+      const license_name: string | null = repoData.license?.name ?? null;
+
+      // Requires @@unique([owner, name], name: "owner_name") on Repo model
+      const repoRow = await prisma.repo.upsert({
+        where: { owner_name: { owner, name } },
+        update: {
+          description: repoData.description ?? null,
+          visibility: repoData.visibility ?? null,
+          default_branch: repoData.default_branch ?? null,
+          created_at: repoData.created_at ? new Date(repoData.created_at) : null,
+          updated_at: repoData.updated_at ? new Date(repoData.updated_at) : null,
+          pushed_at: repoData.pushed_at ? new Date(repoData.pushed_at) : null,
+
+          stargazers_count: repoData.stargazers_count ?? 0,
+          watchers_count: repoData.watchers_count ?? 0,
+          subscribers_count: repoData.subscribers_count ?? 0,
+          forks_count: repoData.forks_count ?? 0,
+
+          branch_count: branchCount,
+          tag_count: tagCount,
+          open_prs_count: openPrsCount,
+          open_issues_count: repoData.open_issues_count ?? 0,
+          size_kb: repoData.size ?? 0,
+          language: repoData.language ?? null,
+          license_name,
+          homepage: repoData.homepage ?? null,
+          topics,
+          last_commit: lastCommitDate ? new Date(lastCommitDate) : null,
+        },
+        create: {
+          owner,
+          name,
+          description: repoData.description ?? null,
+          visibility: repoData.visibility ?? null,
+          default_branch: repoData.default_branch ?? null,
+          created_at: repoData.created_at ? new Date(repoData.created_at) : null,
+          updated_at: repoData.updated_at ? new Date(repoData.updated_at) : null,
+          pushed_at: repoData.pushed_at ? new Date(repoData.pushed_at) : null,
+
+          stargazers_count: repoData.stargazers_count ?? 0,
+          watchers_count: repoData.watchers_count ?? 0,
+          subscribers_count: repoData.subscribers_count ?? 0,
+          forks_count: repoData.forks_count ?? 0,
+
+          branch_count: branchCount,
+          tag_count: tagCount,
+          open_prs_count: openPrsCount,
+          open_issues_count: repoData.open_issues_count ?? 0,
+          size_kb: repoData.size ?? 0,
+          language: repoData.language ?? null,
+          license_name,
+          homepage: repoData.homepage ?? null,
+          topics,
+          last_commit: lastCommitDate ? new Date(lastCommitDate) : null,
+        },
+      });
+
+      // Optional: persist latest commit + users for Overview sync
+      try {
+        const recentRes = await fetch(
+          `https://api.github.com/repos/${repoUrl}/commits?per_page=1`,
+          {
+            headers: {
+              Accept: "application/vnd.github+json",
+              Authorization: `Bearer ${githubAccessToken}`,
+              "User-Agent": "nextjs-app",
+            },
+          }
+        );
+        if (recentRes.ok) {
+          const arr = (await recentRes.json()) as any[];
+          const c = arr?.[0];
+          if (c?.sha) {
+            const author_login = c.author?.login ?? null;
+            const committer_login = c.committer?.login ?? null;
+
+            if (author_login) {
+              await prisma.ghUser.upsert({
+                where: { login: author_login },
+                update: {
+                  avatar_url: c.author?.avatar_url ?? undefined,
+                  type: c.author?.type ?? undefined,
+                },
+                create: {
+                  login: author_login,
+                  avatar_url: c.author?.avatar_url ?? null,
+                  type: c.author?.type ?? null,
+                },
+              });
+            }
+            if (committer_login) {
+              await prisma.ghUser.upsert({
+                where: { login: committer_login },
+                update: {
+                  avatar_url: c.committer?.avatar_url ?? undefined,
+                  type: c.committer?.type ?? undefined,
+                },
+                create: {
+                  login: committer_login,
+                  avatar_url: c.committer?.avatar_url ?? null,
+                  type: c.committer?.type ?? null,
+                },
+              });
+            }
+
+            const committed_at =
+              c.commit?.author?.date
+                ? new Date(c.commit.author.date)
+                : c.commit?.committer?.date
+                ? new Date(c.commit.committer.date)
+                : null;
+
+            await prisma.commit.upsert({
+              where: { sha: c.sha },
+              update: {
+                message: c.commit?.message ?? null,
+                committed_at,
+                repo_id: repoRow.id,
+                author_login: author_login ?? null,
+                committer_login: committer_login ?? null,
+              },
+              create: {
+                sha: c.sha,
+                message: c.commit?.message ?? null,
+                committed_at,
+                repo_id: repoRow.id,
+                author_login: author_login ?? null,
+                committer_login: committer_login ?? null,
+              },
+            });
+          }
+        }
+      } catch {
+        // non-fatal
+      }
+    } catch (dbErr) {
+      console.error("DB persist error:", dbErr);
+      // Do not fail the response
+    }
+
+    // 7) Return unchanged payload for the frontend
     return NextResponse.json(enhancedRepoData);
   } catch (error) {
     console.error("Fetch error:", error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/client/app/repo/page.tsx
+++ b/client/app/repo/page.tsx
@@ -93,7 +93,6 @@ const Page = () => {
     enabled: !!decodedRepo,
   });
 
-
   const topCommittersQuery = useQuery({
     queryKey: ["top-committers", decodedRepo],
     queryFn: () => fetchData("get-top-committers", decodedRepo),
@@ -134,96 +133,132 @@ const Page = () => {
           {/* Row 1 */}
           <div className="bg-white dark:bg-black p-4 rounded-2xl shadow-acternity w-full max-w-md h-auto mx-auto">
             <h2 className="text-xl font-bold mb-2">Repository Overview</h2>
-            {repoQuery.isLoading ? (
+
+            {repoQuery.isPending ? (
               <Skeleton className="h-6 w-full" />
+            ) : repoQuery.isError ? (
+              <p className="text-red-500">
+                {(repoQuery.error as Error)?.message ??
+                  "Failed to load repository"}
+              </p>
             ) : (
-              <div>
-                <p>
-                  <strong>Name:</strong> {repoQuery.data.name}
-                </p>
-                <p>
-                  <strong>Description:</strong> {repoQuery.data.description}
-                </p>
-                <p>
-                  <strong>Stars:</strong> {repoQuery.data.stargazers_count}
-                </p>
-                <p>
-                  <strong>Watchers:</strong>{" "}
-                  {repoQuery.data.subscribers_count ||
-                    repoQuery.data.watchers_count}
-                </p>
-                <p>
-                  <strong>Forks:</strong> {repoQuery.data.forks_count}
-                </p>
-                <p>
-                  <strong>Branches:</strong> {repoQuery.data.branch_count}
-                </p>
-                <p>
-                  <strong>Tags:</strong> {repoQuery.data.tag_count}
-                </p>
-                <p>
-                  <strong>Main Language:</strong> {repoQuery.data.language}
-                </p>
-                <p>
-                  <strong>Size:</strong>{" "}
-                  {(repoQuery.data.size / 1024).toFixed(1)} MB
-                </p>
-                <p>
-                  <strong>License:</strong>{" "}
-                  {repoQuery.data.license?.name || "N/A"}
-                </p>
-                <p>
-                  <strong>Default Branch:</strong>{" "}
-                  {repoQuery.data.default_branch}
-                </p>
-                <p>
-                  <strong>Created:</strong>{" "}
-                  {new Date(repoQuery.data.created_at).toLocaleDateString()}
-                </p>
-                <p>
-                  <strong>Last Updated:</strong>{" "}
-                  {new Date(repoQuery.data.updated_at).toLocaleDateString()}
-                </p>
-                <p>
-                  <strong>Last Commit:</strong>{" "}
-                  {repoQuery.data.last_commit
-                    ? new Date(repoQuery.data.last_commit).toLocaleDateString()
-                    : "N/A"}
-                </p>
-                {repoQuery.data.topics && repoQuery.data.topics.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mt-2">
-                    {repoQuery.data.topics.map((topic : any) => (
-                      <span
-                        key={topic}
-                        className="bg-blue-100 text-blue-700 rounded-full px-2 text-xs font-semibold"
-                      >
-                        {topic}
-                      </span>
-                    ))}
+              (() => {
+                const data = repoQuery.data ?? {};
+
+                const name = data.name ?? "N/A";
+                const description = data.description ?? "—";
+                const stars = data.stargazers_count ?? 0;
+                const watchers =
+                  data.subscribers_count ?? data.watchers_count ?? 0;
+                const forks = data.forks_count ?? 0;
+                const branches = data.branch_count ?? 0;
+                const tags = data.tag_count ?? 0;
+                const language = data.language ?? "—";
+                const sizeKB = typeof data.size === "number" ? data.size : 0;
+                const sizeMB = (sizeKB / 1024).toFixed(1);
+
+                const licenseName =
+                  data.license?.name ?? data.license_name ?? "N/A";
+                const defaultBranch = data.default_branch ?? "—";
+
+                const createdAt = data.created_at
+                  ? new Date(data.created_at).toLocaleDateString()
+                  : "—";
+                const updatedAt = data.updated_at
+                  ? new Date(data.updated_at).toLocaleDateString()
+                  : "—";
+                const lastCommit = data.last_commit
+                  ? new Date(data.last_commit).toLocaleDateString()
+                  : "N/A";
+
+                const topics: string[] = Array.isArray(data.topics)
+                  ? data.topics
+                  : [];
+                const openIssues = data.open_issues_count ?? 0;
+                const openPRs = data.open_prs_count ?? 0;
+                const homepage = data.homepage ?? "";
+
+                return (
+                  <div>
+                    <p>
+                      <strong>Name:</strong> {name}
+                    </p>
+                    <p>
+                      <strong>Description:</strong> {description}
+                    </p>
+                    <p>
+                      <strong>Stars:</strong> {stars}
+                    </p>
+                    <p>
+                      <strong>Watchers:</strong> {watchers}
+                    </p>
+                    <p>
+                      <strong>Forks:</strong> {forks}
+                    </p>
+                    <p>
+                      <strong>Branches:</strong> {branches}
+                    </p>
+                    <p>
+                      <strong>Tags:</strong> {tags}
+                    </p>
+                    <p>
+                      <strong>Main Language:</strong> {language}
+                    </p>
+                    <p>
+                      <strong>Size:</strong> {sizeMB} MB
+                    </p>
+                    <p>
+                      <strong>License:</strong> {licenseName}
+                    </p>
+                    <p>
+                      <strong>Default Branch:</strong> {defaultBranch}
+                    </p>
+                    <p>
+                      <strong>Created:</strong> {createdAt}
+                    </p>
+                    <p>
+                      <strong>Last Updated:</strong> {updatedAt}
+                    </p>
+                    <p>
+                      <strong>Last Commit:</strong> {lastCommit}
+                    </p>
+
+                    {topics.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-2">
+                        {topics.map((topic: string) => (
+                          <span
+                            key={topic}
+                            className="bg-blue-100 text-blue-700 rounded-full px-2 text-xs font-semibold"
+                          >
+                            {topic}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <p>
+                      <strong>Open Issues:</strong> {openIssues}
+                    </p>
+                    <p>
+                      <strong>Open PRs:</strong> {openPRs}
+                    </p>
+
+                    {homepage && (
+                      <p>
+                        <strong>Homepage:</strong>{" "}
+                        <a
+                          href={homepage}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-blue-600"
+                        >
+                          {homepage}
+                        </a>
+                      </p>
+                    )}
                   </div>
-                )}
-                
-                <p>
-                  <strong>Open Issues:</strong>{" "}
-                  {repoQuery.data.open_issues_count}
-                </p>
-                <p>
-                  <strong>Open PRs:</strong> {repoQuery.data.open_prs_count}
-                </p>
-                {repoQuery.data.homepage && (
-                  <p>
-                    <strong>Homepage:</strong>{" "}
-                    <a
-                      href={repoQuery.data.homepage}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline text-blue-600"
-                    >
-                      {repoQuery.data.homepage}
-                    </a>
-                  </p>
-                )}
-              </div>
+                );
+              })()
             )}
           </div>
 
@@ -235,28 +270,30 @@ const Page = () => {
               <>
                 <p>Total Commits: {commitsQuery.data.totalCommits}</p>
                 <ul className="mt-4 space-y-2">
-                  {commitsQuery.data.recentCommits.map((commit:any, idx: number) => (
-                    <li
-                      key={idx}
-                      className="border-b border-gray-200 pb-2 dark:border-gray-700"
-                    >
-                      <p className="font-semibold">
-                        {commit.commit.message
-                          .split(" ")
-                          .slice(0, 10)
-                          .join(" ")}
-                        {commit.commit.message.split(" ").length > 10
-                          ? "..."
-                          : ""}
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        {commit.commit.author.name} on{" "}
-                        {new Date(
-                          commit.commit.author.date
-                        ).toLocaleDateString()}
-                      </p>
-                    </li>
-                  ))}
+                  {commitsQuery.data.recentCommits.map(
+                    (commit: any, idx: number) => (
+                      <li
+                        key={idx}
+                        className="border-b border-gray-200 pb-2 dark:border-gray-700"
+                      >
+                        <p className="font-semibold">
+                          {commit.commit.message
+                            .split(" ")
+                            .slice(0, 10)
+                            .join(" ")}
+                          {commit.commit.message.split(" ").length > 10
+                            ? "..."
+                            : ""}
+                        </p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {commit.commit.author.name} on{" "}
+                          {new Date(
+                            commit.commit.author.date
+                          ).toLocaleDateString()}
+                        </p>
+                      </li>
+                    )
+                  )}
                 </ul>
               </>
             )}
@@ -303,7 +340,7 @@ const Page = () => {
                 <p>Total Issues: {issuesQuery.data.totalCount}</p>{" "}
                 {/* Use totalCount */}
                 <ul className="mt-4 space-y-2">
-                  {issuesQuery.data.issues.map((issue:any, idx: number) => {
+                  {issuesQuery.data.issues.map((issue: any, idx: number) => {
                     const shortTitle =
                       issue.title.split(" ").slice(0, 10).join(" ") +
                       (issue.title.split(" ").length > 10 ? "..." : "");
@@ -332,12 +369,14 @@ const Page = () => {
               <Skeleton className="h-6 w-full" />
             ) : (
               <ul>
-                {contributorsQuery.data.slice(0, 10).map((contrib:any , idx: number) => (
-                  <li key={idx}>
-                    {contrib.login ? contrib.login : "Unknown"} –{" "}
-                    {contrib.contributions ?? "Unknown"} commits
-                  </li>
-                ))}
+                {contributorsQuery.data
+                  .slice(0, 10)
+                  .map((contrib: any, idx: number) => (
+                    <li key={idx}>
+                      {contrib.login ? contrib.login : "Unknown"} –{" "}
+                      {contrib.contributions ?? "Unknown"} commits
+                    </li>
+                  ))}
               </ul>
             )}
           </div>
@@ -410,11 +449,13 @@ const Page = () => {
               <>
                 <p>Total weeks: {participationQuery.data.all.length}</p>
                 <ul className="mt-2 flex-1 overflow-auto scrollbar-hide">
-                  {participationQuery.data.all.map((count : any, idx: number) => (
-                    <li key={idx}>
-                      Week {idx + 1}: {count} commits
-                    </li>
-                  ))}
+                  {participationQuery.data.all.map(
+                    (count: any, idx: number) => (
+                      <li key={idx}>
+                        Week {idx + 1}: {count} commits
+                      </li>
+                    )
+                  )}
                 </ul>
               </>
             )}
@@ -429,20 +470,22 @@ const Page = () => {
               <>
                 <p>Total Releases: {releasesQuery.data.totalCount}</p>
                 <ul className="mt-4 space-y-2">
-                  {releasesQuery.data.releases.map((release : any, idx : number) => (
-                    <li
-                      key={idx}
-                      className="border-b border-gray-200 pb-2 dark:border-gray-700"
-                    >
-                      <p className="font-semibold">
-                        {release.name || release.tag_name}
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400">
-                        Published on{" "}
-                        {new Date(release.published_at).toLocaleDateString()}
-                      </p>
-                    </li>
-                  ))}
+                  {releasesQuery.data.releases.map(
+                    (release: any, idx: number) => (
+                      <li
+                        key={idx}
+                        className="border-b border-gray-200 pb-2 dark:border-gray-700"
+                      >
+                        <p className="font-semibold">
+                          {release.name || release.tag_name}
+                        </p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          Published on{" "}
+                          {new Date(release.published_at).toLocaleDateString()}
+                        </p>
+                      </li>
+                    )
+                  )}
                 </ul>
               </>
             )}

--- a/client/lib/prisma.ts
+++ b/client/lib/prisma.ts
@@ -1,0 +1,15 @@
+// lib/prisma.ts
+import { PrismaClient } from "@prisma/client";
+
+// Ensure Node.js runtime in routes that import this
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "client",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/react": "^2.0.47",
         "@ai-sdk/rsc": "^1.0.48",
+        "@prisma/client": "^6.16.2",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -51,6 +53,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
+        "prisma": "^6.16.2",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.7",
         "typescript": "^5"
@@ -1292,6 +1295,91 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
+      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.2.tgz",
+      "integrity": "sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.16.12",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.2.tgz",
+      "integrity": "sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.2.tgz",
+      "integrity": "sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2",
+        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+        "@prisma/fetch-engine": "6.16.2",
+        "@prisma/get-platform": "6.16.2"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
+      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.2.tgz",
+      "integrity": "sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2",
+        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
+        "@prisma/get-platform": "6.16.2"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.2.tgz",
+      "integrity": "sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.16.2"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3830,6 +3918,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4015,6 +4132,22 @@
         "chevrotain": "^11.0.0"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4023,6 +4156,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/class-variance-authority": {
@@ -4128,6 +4271,16 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -4781,6 +4934,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4817,6 +4980,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -4834,6 +5004,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -4892,6 +5069,19 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4905,6 +5095,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.16.12",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
+      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
       }
     },
     "node_modules/embla-carousel": {
@@ -4941,6 +5142,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -5615,6 +5826,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5922,6 +6156,24 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob-parent": {
@@ -7289,7 +7541,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9248,6 +9500,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/nypm": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
+      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.2",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9370,6 +9649,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
@@ -9565,6 +9851,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9679,6 +9972,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prisma": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
+      "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.16.2",
+        "@prisma/engines": "6.16.2"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -9723,6 +10042,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -9759,6 +10095,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -9928,6 +10275,20 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11196,7 +11557,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/client/package.json
+++ b/client/package.json
@@ -3,14 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
-    "start": "next start",
-    "lint": "eslint"
+      "dev": "npm run generate && next dev",
+      "build": "npm run generate && next build",
+      "generate": "npx prisma generate"
+,
+    "lint": "eslint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.47",
     "@ai-sdk/rsc": "^1.0.48",
+    "@prisma/client": "^6.16.2",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -52,6 +55,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
+    "prisma": "^6.16.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.7",
     "typescript": "^5"

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -1,0 +1,214 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+/*
+  Core: Repo and GhUser
+  - Adds counters used by the UI (stars, watchers/subscribers, forks, branch_count, tag_count, open_prs_count, open_issues_count, size, language, license_name, homepage, topics).
+  - Adds last_commit for “Repository Overview”.
+*/
+
+model Repo {
+  id               BigInt    @id @default(autoincrement())
+  owner            String
+  name             String
+  description      String?
+  visibility       String?
+  default_branch   String?
+  created_at       DateTime?
+  updated_at       DateTime?
+  pushed_at        DateTime?
+
+  // Overview counters used by the page
+  stargazers_count Int       @default(0)
+  watchers_count   Int       @default(0)          // GitHub legacy watchers (equals stars for REST v3)
+  subscribers_count Int      @default(0)          // “Watchers” (subscribers) used by UI fallback
+  forks_count      Int       @default(0)
+  branch_count     Int       @default(0)          // precomputed in ingestion
+  tag_count        Int       @default(0)          // precomputed in ingestion
+  open_prs_count   Int       @default(0)
+  open_issues_count Int      @default(0)
+  size_kb          Int       @default(0)          // GitHub repo.size returns KB; UI divides by 1024
+  language         String?                           // main language
+  license_name     String?                           // license?.name
+  homepage         String?
+  topics           String[]  @default([])           // used by the chips
+  last_commit      DateTime?                         // latest commit timestamp
+
+  // Relations
+  commits          Commit[]
+  issues           Issue[]
+  pulls            Pull[]
+  releases         Release[]
+  languages        RepoLanguage[]
+  participation    ParticipationStats[]
+  weeklyCommits    WeeklyCommit[]                   // for “Commits This Year”
+  contributorRanks ContributorRank[]                // for “Top Committers”
+
+  @@unique([owner, name], map: "owner_name")
+  @@index([updated_at])
+  @@index([pushed_at])
+}
+
+model GhUser {
+  id         BigInt   @id @default(autoincrement())
+  login      String   @unique
+  avatar_url String?
+  type       String?
+
+  commits_authored  Commit[] @relation("Author")
+  commits_committed Commit[] @relation("Committer")
+  issues            Issue[]  @relation("IssueAuthor")
+  pulls             Pull[]   @relation("PullAuthor")
+
+  contributorRanks  ContributorRank[]
+}
+
+/*
+  Commits, Issues, Pulls, Releases
+  - Keep shapes compatible with UI and queries.
+*/
+
+model Commit {
+  id             BigInt   @id @default(autoincrement())
+  sha            String   @unique
+  message        String?
+  committed_at   DateTime?
+  repo_id        BigInt
+  repo           Repo     @relation(fields: [repo_id], references: [id])
+
+  // Relations to GhUser
+  author_login   String?
+  author         GhUser?  @relation("Author", fields: [author_login], references: [login])
+  committer_login String?
+  committer       GhUser? @relation("Committer", fields: [committer_login], references: [login])
+
+  @@index([repo_id, committed_at])
+}
+
+model Issue {
+  id            BigInt   @id @default(autoincrement())
+  issue_number  Int
+  title         String?
+  state         String?                         // open/closed
+  created_at    DateTime?
+  updated_at    DateTime?
+  closed_at     DateTime?
+  repo_id       BigInt
+  repo          Repo     @relation(fields: [repo_id], references: [id])
+
+  author_login  String?
+  author        GhUser?  @relation("IssueAuthor", fields: [author_login], references: [login])
+
+  @@unique([repo_id, issue_number])
+  @@index([repo_id, state, created_at])
+}
+
+model Pull {
+  id           BigInt   @id @default(autoincrement())
+  pr_number    Int
+  title        String?
+  state        String?                         // open/closed
+  created_at   DateTime?
+  updated_at   DateTime?
+  closed_at    DateTime?
+  merged_at    DateTime?
+  repo_id      BigInt
+  repo         Repo     @relation(fields: [repo_id], references: [id])
+
+  author_login String?
+  author       GhUser?  @relation("PullAuthor", fields: [author_login], references: [login])
+
+  @@unique([repo_id, pr_number])
+  @@index([repo_id, state, created_at])
+  @@index([repo_id, merged_at])
+}
+
+model Release {
+  id            BigInt   @id @default(autoincrement())
+  release_id    BigInt   @unique                 // GitHub numeric id
+  tag_name      String?
+  name          String?
+  created_at    DateTime?
+  published_at  DateTime?
+  repo_id       BigInt
+  repo          Repo     @relation(fields: [repo_id], references: [id])
+
+  @@index([repo_id, published_at])
+}
+
+/*
+  Languages panel
+  - Unique per (repo, language) to support idempotent upserts.
+  - Store bytes to match UI listing.
+*/
+
+model RepoLanguage {
+  id            BigInt  @id @default(autoincrement())
+  language      String
+  bytes_of_code BigInt
+  repo_id       BigInt
+  repo          Repo    @relation(fields: [repo_id], references: [id])
+
+  @@unique([repo_id, language])
+  @@index([repo_id])
+}
+
+/*
+  Participation (all/owner arrays in the UI)
+  - Store weekly bucket with both all_commits and owner_commits.
+  - Unique per (repo, week_start) for dedupe.
+*/
+
+model ParticipationStats {
+  id            BigInt   @id @default(autoincrement())
+  week_start    DateTime                             // normalized to Sunday UTC
+  all_commits   Int
+  owner_commits Int
+  repo_id       BigInt
+  repo          Repo     @relation(fields: [repo_id], references: [id])
+
+  @@unique([repo_id, week_start])
+  @@index([repo_id, week_start])
+}
+
+/*
+  Commits This Year chart
+  - If using a separate endpoint returning [{week, total}], keep a compact table for the current rolling year.
+  - week is an ISO week-start date string or DateTime; UI reads .week and .total.
+*/
+
+model WeeklyCommit {
+  id        BigInt   @id @default(autoincrement())
+  repo_id   BigInt
+  repo      Repo     @relation(fields: [repo_id], references: [id])
+  week      DateTime                             // start of week (UTC)
+  total     Int
+
+  @@unique([repo_id, week])
+  @@index([repo_id, week])
+}
+
+/*
+  Top Committers (horizontal bar)
+  - Snapshot table keyed by (repo, user). “contributions” feeds the chart and the contributors list.
+  - Keep in sync with GitHub /commits or /contributors endpoint during ingestion.
+*/
+
+model ContributorRank {
+  id            BigInt  @id @default(autoincrement())
+  repo_id       BigInt
+  repo          Repo    @relation(fields: [repo_id], references: [id])
+  user_login    String
+  user          GhUser? @relation(fields: [user_login], references: [login])
+  contributions Int      @default(0)
+
+  @@unique([repo_id, user_login])
+  @@index([repo_id, contributions])
+}


### PR DESCRIPTION
Title
Persist “Repository Overview” to DB with Prisma; fix Prisma Client initialization error in Next.js route

Description

Implemented DB persistence for /api/get-repo without changing the API response shape. The route still fetches from GitHub and now upserts Repo (and optionally latest Commit + GhUser) to Neon via Prisma.

Encountered and fixed “@prisma/client did not initialize yet. Please run 'prisma generate'” which occurred because the route was evaluated before a generated client existed and imports didn’t match the generator output.

Moved Prisma to a singleton (lib/prisma.ts), ensured Node.js runtime for the route, and added prisma generate to install/dev/build scripts.

What was changed

app/api/get-repo/route.ts

Kept the existing GitHub fetch logic.

Added Prisma upserts for Repo fields: stargazers_count, watchers_count, subscribers_count, forks_count, branch_count, tag_count, open_prs_count, open_issues_count, size_kb, language, license_name, homepage, topics, last_commit.

Optional upsert of latest commit + users to keep Overview aligned.

Exported runtime = "nodejs".

lib/prisma.ts

Added Prisma singleton to avoid multiple clients in dev/hot reload.

package.json

Added "postinstall": "prisma generate".

Prefixed dev/build with prisma generate.

How to reproduce (before)

Start dev server.

Call GET /api/get-repo?repoUrl=facebook/react.

Observe 500 with “@prisma/client did not initialize yet…” during route module evaluation.

How to verify (after)

Clean and generate:

Windows PowerShell:

Remove-Item -Recurse -Force .next

npx prisma generate

npm run dev

Call GET /api/get-repo?repoUrl=facebook/react.

Expect 200 JSON identical to before, and Neon Repo row upserted/updated with overview fields.

UI “Repository Overview” renders; no runtime errors.``